### PR TITLE
Add tox and workflow to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Run tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          python manage.py test --settings=team.test_settings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .idea
 site_settings.py
 venv
-
+.tox
+*.egg-info

--- a/ballots/models.py
+++ b/ballots/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from people.models import Person, Level
 

--- a/people/models.py
+++ b/people/models.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Level(models.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ pyparsing==2.4.7
 pytz==2020.1
 six==1.15.0
 sqlparse==0.4.1
+tox==3.27.1
 webencodings==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+import os
+
+from setuptools import setup, find_packages
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+requires = [
+    "django",
+]
+
+setup(
+    name="team",
+    version="0.0",
+    description="Team Intranet",
+    long_description="",
+    classifiers=[
+        "Programming Language :: Python",
+        "Framework :: Django",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
+    ],
+    author="Igalia",
+    url="igalia.com",
+    keywords="web wsgi django",
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    test_suite="team",
+    install_requires=requires,
+)

--- a/skills/models.py
+++ b/skills/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from people.models import Person, Team
 

--- a/skills/views.py
+++ b/skills/views.py
@@ -6,7 +6,7 @@ from django.http.response import Http404, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from common.auth import get_user_login
 from people.models import Person, Team

--- a/team/settings.py
+++ b/team/settings.py
@@ -13,8 +13,6 @@ import os
 # noinspection PyUnresolvedReferences
 from pathlib import Path
 
-from .site_settings import *
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -146,3 +144,8 @@ def set_target_blank(attrs, new=False):
 
 MARKDOWNIFY_LINKIFY_CALLBACKS = [set_target_blank, ]
 MARKDOWNIFY_MARKDOWN_EXTENSIONS = ['markdown.extensions.extra',]
+
+try:
+    from .site_settings import *
+except ImportError:
+    pass

--- a/team/settings.py
+++ b/team/settings.py
@@ -10,6 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 import os
+import logging
+
 # noinspection PyUnresolvedReferences
 from pathlib import Path
 
@@ -136,6 +138,7 @@ MARKDOWNIFY_WHITELIST_TAGS = [
     'ul'
 ]
 
+logger = logging.getLogger(__name__)
 
 def set_target_blank(attrs, new=False):
     attrs[(None, u'target')] = u'blank'
@@ -148,4 +151,5 @@ MARKDOWNIFY_MARKDOWN_EXTENSIONS = ['markdown.extensions.extra',]
 try:
     from .site_settings import *
 except ImportError:
+    logger.warning('Default settings are not good for the production environment')
     pass

--- a/team/test_settings.py
+++ b/team/test_settings.py
@@ -1,0 +1,14 @@
+from .settings import *
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "localdb.sqlite3",
+    }
+}
+
+DEBUG = True
+
+USE_BASIC_AUTH = False
+
+SECRET_KEY = "secret-key"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist =
+    py38,
+    py39
+
+[testenv]
+description = run tests
+deps = -rrequirements.txt
+commands = ./manage.py test --settings=team.test_settings

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py38,
-    py39
+    py39,
+    py310
 
 [testenv]
 description = run tests


### PR DESCRIPTION
These tools will make the tests and lint checking way easier.

It's possible to run the tests by running `pytest` or `tox` commands. The main difference for now is that with `tox`, it tests in both python 3.8 and 3.9 environments.

Soon I'll also add the lint and coverage stages in the `tox.ini` file, so running `tox` can make all the code checks at once.

Since the tests needed a database, I've added in the settings file a simple SQLite config as a default db.