### PR TITLE
Add black and flake8 checks in tox and github actions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501
+exclude = .git,__pycache__,venv,.tox, */migrations/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
@@ -27,3 +27,11 @@ jobs:
       - name: Run tests
         run: |
           python manage.py test --settings=team.test_settings
+      - name: Run flake8 check
+        run: |
+          tox -e flake8
+        continue-on-error: true
+      - name: Run black check
+        run: |
+          tox -e black
+        continue-on-error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 120
+extend-exclude = '''
+/(
+  | migrations
+)/
+'''

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,25 @@
 envlist =
     py38,
     py39,
-    py310
+    py310,
+    black,
+    flake8
 
 [testenv]
 description = run tests
 deps = -rrequirements.txt
 commands = ./manage.py test --settings=team.test_settings
+
+[testenv:black]
+basepython = python3
+usedevelop = false
+deps = black
+changedir = {toxinidir}
+commands = black --check --diff .
+
+[testenv:flake8]
+basepython = python3
+usedevelop = false
+deps = flake8 >= 3.7.0
+changedir = {toxinidir}
+commands = flake8 .


### PR DESCRIPTION
This is an initial proposal to add code style and lint checks in the repository.

I chose black for some personal reasons: I've been using it for a while integrated with my code editor and I really like the productivity it gives me and not having to think about formatting the code, but I'm not a very optioned person for code formatting so I've added it with the default settings which we can definitely tweak, in the file `pyproject.toml`.

flake8 is the default choice to check the code styles from pep8, that's why I've added it too.

Next step would be to add pre-commit, so these checks would be done locally too before committing, but I would do that after we agree on the style we want to follow and after fixing the files to follow the chosen style.